### PR TITLE
Fix clicking another month not navigating

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -27,7 +27,7 @@ export default React.createClass({
   },
 
   _resetDate () {
-    this.refs.calendar.resetDate();
+    this.refs.calendar.changeDate();
   },
 
 

--- a/client/components/calendar/calendar.js
+++ b/client/components/calendar/calendar.js
@@ -22,11 +22,6 @@ class Calendar extends React.Component {
     viewDate: this.props.selectedDate
   }
 
-  handleDayClick (day) {
-    this.setState({selectedDate: day});
-    if (this.props.onChange) this.props.onChange(day);
-  }
-
   incrementViewMonth () {
     this.setState({
       direction: 'right',
@@ -41,15 +36,13 @@ class Calendar extends React.Component {
     });
   }
 
-  resetDate () {
-    var d = new Date();
-
-    var direction = d.getTime() < this.state.viewDate.getTime() ? 'left' : 'right';
+  changeDate (d = new Date()) {
+    const direction = d.getTime() < this.state.viewDate.getTime() ? 'left' : 'right';
 
     this.setState({
       selectedDate: d,
       viewDate: d,
-      direction: direction
+      direction
     });
 
     if (this.props.onChange) this.props.onChange(d);
@@ -76,7 +69,7 @@ class Calendar extends React.Component {
           viewDate={this.state.viewDate}
           events={events}
           selectedDate={this.state.selectedDate}
-          onDayClick={this.handleDayClick.bind(this)} />
+          onDayClick={this.changeDate.bind(this)} />
       </CSSTransitionGroup>
     );
   }
@@ -87,7 +80,7 @@ class Calendar extends React.Component {
       <div className="calendar">
         <div className="header">
           <CSSTransitionGroup transitionName={animation} transitionEnterTimeout={200} transitionLeaveTimeout={200} component="div" className="date">
-            <div onClick={this.resetDate.bind(this)} key={this.state.viewDate.getMonth()} className="date" >
+            <div onClick={this.changeDate.bind(this)} key={this.state.viewDate.getMonth()} className="date" >
               <span className="month">{ time.getFullMonth(this.state.viewDate)}</span>
               <span className="year">{ this.state.viewDate.getFullYear() }</span>
             </div>


### PR DESCRIPTION
When you click on dates in a month other than the current one, the day is selected, but you're not navigated to it.
![](http://g.recordit.co/9h8DxAyPfU.gif)

This navigates the calendar to the month of the selected day.
![](http://g.recordit.co/90i0TcUUog.gif)

I also combined `handleDayClick` and `resetDate` into `changeDate` as they both were now doing the same thing.

This will conflict with #10 calling `resetDate`, so if you accept it I'll update this.
