### PR TITLE
Hide dev tools behind node-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rimraf": "^2.4.4"
   },
   "scripts": {
+    "dev": "NODE_ENV=development npm start",
     "start": "./node_modules/.bin/electron .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -86,13 +86,15 @@ ipc.on('auth.get', async function (event) {
 });
 
 
-/*
- * Open dev tools after window is shown
- */
+if (process.env.NODE_ENV === 'development') { 
+  /*
+  * Open dev tools after window is shown
+  */
 
-mb.on('after-show', function () {
-  mb.window.openDevTools({ detach: true })
-});
+  mb.on('after-show', function () {
+    mb.window.openDevTools({ detach: true })
+  });
+}
 
 
 /*


### PR DESCRIPTION
Not a menu, but quick fix for #6 to not have to comment it out for using it day to day.
