### PR TITLE
Navigate to date when events or date headers are clicked

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,4 +1,7 @@
-import { ipcRenderer as ipc } from 'electron'
+import {
+  ipcRenderer as ipc,
+  shell
+} from 'electron'
 
 var React = require('react');
 var Icon = require('./components/icon');
@@ -42,6 +45,25 @@ export default React.createClass({
 
 
   /*
+   * When a header is clicked, select the date
+   */
+
+  _handleHeaderClick (date) {
+    this.refs.calendar.changeDate(date, true);
+  },
+
+
+  /*
+   * When an event is clicked, open in browser
+   */
+
+  _handleEventClick (event) {
+    this.refs.calendar.changeDate(new Date(event.start.dateTime), true);
+    shell.openExternal(event.htmlLink);
+  },
+
+
+  /*
    * Render
    */
 
@@ -50,7 +72,7 @@ export default React.createClass({
       <div className="flex-column">
         <Toolbar key="toolbar" profile={this.state.profile}/>
         <Calendar ref="calendar" key="calendar" view={this.state.view} events={this.state.events} selectedDate={new Date()} onChange={this._handleCalendarSelect}/>
-        <EventList ref="eventlist" key="events" events={this.state.events}/>
+        <EventList ref="eventlist" key="events" onHeaderClick={this._handleHeaderClick} onEventClick={this._handleEventClick} events={this.state.events}/>
       </div>
     );
   }

--- a/client/components/calendar/calendar.js
+++ b/client/components/calendar/calendar.js
@@ -32,7 +32,7 @@ class Calendar extends React.Component {
     }
   }
 
-  changeDate (d = new Date()) {
+  changeDate (d = new Date(), silent = false) {
     const direction = d.getTime() < this.state.viewDate.getTime() ? 'left' : 'right';
 
     this.setState({
@@ -41,7 +41,7 @@ class Calendar extends React.Component {
       direction
     });
 
-    if (this.props.onChange) this.props.onChange(d);
+    if (this.props.onChange && !silent) this.props.onChange(d);
   }
 
   getEventsThisMonth () {

--- a/client/components/calendar/month.js
+++ b/client/components/calendar/month.js
@@ -8,11 +8,11 @@ class Month extends React.Component {
     selectedDate: React.PropTypes.object,
     viewDate: React.PropTypes.object,
     events: React.PropTypes.array
-  };
+  }
 
   handleDayClick (day) {
     if (this.props.onDayClick) this.props.onDayClick(day);
-  };
+  }
 
   renderWeeks () {
     var weeks = [];

--- a/client/components/event-list.js
+++ b/client/components/event-list.js
@@ -1,4 +1,3 @@
-import { shell } from 'electron';
 import React from 'react';
 import moment from 'moment';
 import time from './calendar/timeUtils';
@@ -110,6 +109,29 @@ export default React.createClass({
 
 
   /*
+   *  Handle when an event is clicked on
+   */
+
+  _handleEventClick (event) {
+    if (this.props.onEventClick) {
+      this.props.onEventClick(event);
+    }
+  },
+
+
+  /*
+   * Handle when a group header is clicked on
+   */
+
+  _handleHeaderClick (group) {
+    if (this.props.onHeaderClick) {
+      const d = new Date(group.substr(group.indexOf(' ') + 1));
+      this.props.onHeaderClick(d);
+    }
+  },
+
+
+  /*
    * Render the individual event item
    */
 
@@ -123,7 +145,7 @@ export default React.createClass({
     var isCurrent = now >= start && now <= end;
 
     return (
-      <div key={idx} onClick={shell.openExternal.bind(null, event.htmlLink)} className={"event" + (isPast ? ' past' : '') + (isCurrent ? ' current' : '')}>
+      <div key={idx} onMouseDown={this._handleEventClick.bind(this, event)} className={"event" + (isPast ? ' past' : '') + (isCurrent ? ' current' : '')}>
         <div className="name">
           {name}
           <div className="location">
@@ -143,7 +165,7 @@ export default React.createClass({
   render () {
     var items = _.map(this.state.groupedEvents, (subItems, key) => {
       var header = (
-        <div ref={key} className="event-list-header">{key}</div>
+        <div ref={key} className="event-list-header" onMouseDown={this._handleHeaderClick.bind(this, key)}>{key}</div>
       );
       var els = subItems.map((e, i) => {
         return this._renderEvent(e, i);


### PR DESCRIPTION
@michaeljacobdavis FYI: I moved the event browser window behavior to app.js. I wanted to add the date navigation behavior for events and date headers. I think keeping electron related code out of the sub components makes sense too, but we'll see.
